### PR TITLE
ci: enable dependabot github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,27 @@
-version: 2
 updates:
-  - package-ecosystem: npm
+  - allow:
+      - dependency-type: direct
+    commit-message:
+      include: scope
+      prefix: chore
     directory: /
+    open-pull-requests-limit: 99
+    package-ecosystem: github-actions
+    reviewers:
+      - 'ridedott/platform'
     schedule:
       interval: daily
-    allow:
-      - dependency-type: all
+  - allow:
       - dependency-type: direct
-    ignore:
-      - dependency-name: '@types/node'
-        versions:
-          - '> 12'
-    versioning-strategy: increase
     commit-message:
-      prefix: chore
       include: scope
+      prefix: chore
+    directory: /
+    open-pull-requests-limit: 99
+    package-ecosystem: npm
+    reviewers:
+      - 'ridedott/back-end'
+    schedule:
+      interval: daily
+    versioning-strategy: increase
+version: 2


### PR DESCRIPTION
No private packages are being used in this repository, so there is no need to configure dependabot to work with private registries.

Also, this repository will/might be shared with people that do not have organization credentials, so it's important for it to have a valid configuration for public use.

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

Resolves #
